### PR TITLE
Accordion now fills the full page

### DIFF
--- a/style.css
+++ b/style.css
@@ -200,6 +200,10 @@ section div {
   }
 }
 
+.accordion {
+  display: block;
+}
+
 .accordion-item {
   display: block;
 }


### PR DESCRIPTION
![bild](https://github.com/user-attachments/assets/f700c439-0749-4321-8147-c3c3e67a0e61)
